### PR TITLE
[TASK] Deactivate Edit on GitHub

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -11,8 +11,9 @@ copyright   = since 2018 by the TYPO3 contributors
 [html_theme_options]
 
 # "Edit on GitHub" button
-github_repository    = TYPO3-Documentation/TYPO3CMS-Reference-ViewHelper
-github_branch        = master
+# !!! Do not show "Edit on GitHub" in automatically generated VH ref
+#github_repository    = TYPO3-Documentation/TYPO3CMS-Reference-ViewHelper
+#github_branch        = main
 
 # Footer links
 project_home         = https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/


### PR DESCRIPTION
The "Edit on GitHub" button should not make editing the generated
documentation available.

Ideally, the "Edit on GitHub" should refer to the source code in the
respective TYPO3 / Fluid repository. Deactivating it is a temporary
solution until linking to the source code can be made available.

Related: #9
Releases: main, 11.5, 10.4, 9.5, 8.7