### PR TITLE
[TASK] Replace "Edit on GitHub" workflow with contribution page

### DIFF
--- a/Documentation/Contribution/Index.rst
+++ b/Documentation/Contribution/Index.rst
@@ -1,0 +1,10 @@
+.. include:: /Includes.rst.txt
+
+============
+Contribution
+============
+
+Since the ViewHelper documentation is maintained in the TYPO3 Core source files
+and version 8.7 is no longer maintained, this documentation can also no longer
+be edited. Maybe you want to include your changes in one of the later
+documentation versions?

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -62,5 +62,6 @@ from the PHP source code of TYPO3 CMS and the package names do not correspond
 .. toctree::
    :hidden:
 
+   Contribution/Index
    Sitemap
    genindex

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -11,8 +11,9 @@ copyright   = since 2018 by the TYPO3 contributors
 [html_theme_options]
 
 # "Edit on GitHub" button
-github_repository    = TYPO3-Documentation/TYPO3CMS-Reference-ViewHelper
-github_branch        = 8.7
+# !!! Do not show "Edit on GitHub" in automatically generated ViewHelper reference
+# github_repository    = TYPO3-Documentation/TYPO3CMS-Reference-ViewHelper
+# github_branch        = 8.7
 
 # Footer links
 project_home         = https://docs.typo3.org/other/typo3/view-helper-reference/8.7/en-us/
@@ -26,7 +27,7 @@ use_opensearch       =
 [intersphinx_mapping]
 
 # Official TYPO3 manuals
-# h2document     = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
+h2document     = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
 # t3cheatsheets  = https://docs.typo3.org/m/typo3/docs-cheatsheets/main/en-us/
 # t3contribute   = https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/
 # t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/


### PR DESCRIPTION
Most of the ViewHelper documentation is generated from the ViewHelper
source code. Therefore, the "Edit on GitHub" workflow is
counterproductive because it applies PRs to the reST files that will
be overwritten during the next generation run. Remove the
"Edit on GitHub" workflow and instead add a contribution page that
explains all the manual steps.

Removed the redundant /CONTRIBUTING.rst file - it is not at hand when
reading the documentation.

Relates: #63