### PR TITLE
[TASK] Update data type for useNonce argument

### DIFF
--- a/Documentation/typo3/fluid/latest/Asset/Css.rst
+++ b/Documentation/typo3/fluid/latest/Asset/Css.rst
@@ -367,7 +367,7 @@ useNonce
 --------
 
 :aspect:`DataType`
-   mixed
+   boolean
 
 :aspect:`Required`
    false

--- a/Documentation/typo3/fluid/latest/Asset/Script.rst
+++ b/Documentation/typo3/fluid/latest/Asset/Script.rst
@@ -314,7 +314,7 @@ useNonce
 --------
 
 :aspect:`DataType`
-   mixed
+   boolean
 
 :aspect:`Required`
    false


### PR DESCRIPTION
According to `TYPO3\CMS\Fluid\ViewHelpers\Asset\CssViewHelper` and `TYPO3\CMS\Fluid\ViewHelpers\Asset\ScriptViewHelper` the argument `useNonce` should be of type `boolean`.