### PR TITLE
[TASK] List Form ViewHelper and Sub View helpers together

### DIFF
--- a/Documentation/Global/Form.rst
+++ b/Documentation/Global/Form.rst
@@ -1,37 +1,11 @@
+:orphan:
 :navigation-title: form
 
 ..  include:: /Includes.rst.txt
-..  _typo3-fluid-form:
 
 ==========================
 Form ViewHelper `<f:form>`
 ==========================
 
-..  typo3:viewhelper:: form
-    :source: ../Global.json
-    :display: tags,description,gitHubLink,arguments
-
-..  _typo3-fluid-form-example:
-
-Examples
-========
-
-A complex form with a specified encoding type
----------------------------------------------
-
-Form with enctype set::
-
-   <f:form action=".." controller="..." package="..." enctype="multipart/form-data">...</f:form>
-
-A Form which should render a domain object
-------------------------------------------
-
-Binding a domain object to a form::
-
-   <f:form action="..." name="customer" object="{customer}">
-      <f:form.hidden property="id" />
-      <f:form.textarea property="name" />
-   </f:form>
-
-This automatically inserts the value of ``{customer.name}`` inside the
-textarea and adjusts the name of the textarea accordingly.
+..  seealso::
+    See `Form ViewHelper <f:form> <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-form>`_

--- a/Documentation/Global/Form/Index.rst
+++ b/Documentation/Global/Form/Index.rst
@@ -1,9 +1,46 @@
+:navigation-title: form
+
 ..  include:: /Includes.rst.txt
+..  _typo3-fluid-form:
 
-====
-Form
-====
+==========================
+Form ViewHelper `<f:form>`
+==========================
 
+..  typo3:viewhelper:: form
+    :source: /Global.json
+    :display: tags,description,gitHubLink,arguments
+
+..  _typo3-fluid-form-example:
+
+Examples
+========
+
+A complex form with a specified encoding type
+---------------------------------------------
+
+Form with enctype set::
+
+   <f:form action=".." controller="..." package="..." enctype="multipart/form-data">...</f:form>
+
+A Form which should render a domain object
+------------------------------------------
+
+Binding a domain object to a form::
+
+   <f:form action="..." name="customer" object="{customer}">
+      <f:form.hidden property="id" />
+      <f:form.textarea property="name" />
+   </f:form>
+
+This automatically inserts the value of ``{customer.name}`` inside the
+textarea and adjusts the name of the textarea accordingly.
+
+
+..  _typo3-fluid-form-viewhelpers:
+
+ViewHelpers to be used within the form ViewHelper
+=================================================
 
 ..  toctree::
     :titlesonly:

--- a/Documentation/Global/Index.rst
+++ b/Documentation/Global/Index.rst
@@ -8,6 +8,7 @@ Global (f:*)
 ..  toctree::
     :titlesonly:
     :glob:
+    :globExclude: Form
 
     */Index
     *


### PR DESCRIPTION
Until now, the form ViewHelper itself was listed at the bottom of the menu, its subviewhelpers on top within a directory. As they are used together I moved them into one location now, hiding the former form viewhelper page as orphan so it does not get regenerated.

Update of Form examples tbd I just moved them for the time beeing

Releases: main, 13.4