### PR TITLE
[TASK] Update f:form.select ViewHelper page

### DIFF
--- a/Documentation/Global/Form/Select.rst
+++ b/Documentation/Global/Form/Select.rst
@@ -8,77 +8,317 @@ Form.select ViewHelper `<f:form.select>`
 ========================================
 
 ..  typo3:viewhelper:: form.select
-    :source: ../../Global.json
-    :display: tags,description,gitHubLink,arguments
+    :source: /Global.json
+    :display: tags,description,gitHubLink
+    :noindex:
+
+..  include:: /_Includes/_ExtbaseFormViewHelpers.rst.txt
+
+..  contents:: Table of contents
 
 ..  _typo3-fluid-form-select-usage:
 
-Basic usage
-===========
+Select field with hardcoded options
+===================================
 
-The most straightforward way is to supply an associative array as the ``options`` parameter.
-The array key is used as option key, and the value is used as human-readable name.
+Using the
+:ref:`options <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-form-selectviewhelper-options>`
+parameter, you can pass a hardcoded array to the form.select ViewHelper.
 
-Basic usage::
+The key of that array is used as option key, and the value is used as
+human-readable name.
 
-   <f:form.select name="paymentOptions" options="{payPal: 'PayPal International Services', visa: 'VISA Card'}" />
+..  tabs::
 
-Pre select a value
-------------------
+    ..  group-tab:: Fluid
 
-To pre select a value, set ``value`` to the option key which should be selected.
-Default value::
+        ..  literalinclude:: _codesnippets/_SelectGender.html
+            :caption: packages/my_extension/Resources/Private/Templates/User/GenderForm.html
 
-   <f:form.select name="paymentOptions" options="{payPal: 'PayPal International Services', visa: 'VISA Card'}" value="visa" />
+    ..  group-tab:: Controller
 
-Generates a dropdown box like above, except that "VISA Card" is selected.
+        The argument for will have the key of the chosen entry as value.
 
-If the select box is a multi-select box :html:`multiple="1"`, then "value" can be an array as well.
+        ..  literalinclude:: _codesnippets/_SelectGender.php
+            :caption: packages/my_extension/Classes/Controller/UserController.php
 
-Custom options and option group rendering
------------------------------------------
+..  _typo3-fluid-form-select-usage-array:
 
-Child nodes can be used to create a completely custom set of
-:html:`<option>` and :html:`<optgroup>` tags in a way compatible with the
+Preselected field with options supplied by the controller
+=========================================================
+
+Most options will be supplied by the controller. You can pass an associative
+array with the options to the view:
+
+..  tabs::
+
+    ..  group-tab:: Fluid
+
+        ..  literalinclude:: _codesnippets/_SelectPayment.html
+            :caption: packages/my_extension/Resources/Private/Templates/User/PaymentForm.html
+
+    ..  group-tab:: Controller
+
+        The argument for the select field will have the key of the chosen entry as value.
+
+        ..  literalinclude:: _codesnippets/_SelectPayment.php
+            :caption: packages/my_extension/Classes/Controller/UserController.php
+
+To pre select a value, use the argument
+:ref:`value <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-form-selectviewhelper-value>`.
+
+..  _typo3-fluid-form-select-usage-models:
+
+Select field for selecting (persisted) models
+=============================================
+
+Consider we have the payment options from the previous example in the database
+and in an Extbase model:
+
+
+..  tabs::
+
+    ..  group-tab:: Model
+
+        ..  literalinclude:: _codesnippets/_SelectPaymentMethod.php
+            :caption: packages/my_extension/Classes/Domain/Model/PaymentMethod.php
+
+    ..  group-tab:: Controller
+
+        In the controller we can get all payment methods from the from the
+        `Repository <https://docs.typo3.org/permalink/t3coreapi:extbase-repository>`_
+        now and pass it to the view as variable:
+
+        ..  literalinclude:: _codesnippets/_SelectPaymentModelController.php
+            :caption: packages/my_extension/Classes/Controller/UserController.php
+
+    ..  group-tab:: Fluid
+
+        The Fluid template can be left unchanged even though we are dealing with a
+        different data source:
+
+        ..  literalinclude:: _codesnippets/_SelectPayment.html
+            :caption: packages/my_extension/Resources/Private/Templates/User/PaymentForm.html
+
+When the form gets submitted, the UID of the chosen model appears in the request
+data. Extbase will then map that uid back to the model for you.
+
+The ViewHelper will then use the models UID as data submitted in the from and
+the result of method :php:`__toString()` as display text.
+
+..  note::
+    You can pass any array or :php:`\Traversable` object to
+    the :ref:`options <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-form-selectviewhelper-options>`
+    argument. This includes the result of `findBy()` methods on
+    `Extbase repositories <https://docs.typo3.org/permalink/t3coreapi:extbase-repository>`_,
+    :php-short:`\TYPO3\CMS\Extbase\Persistence\QueryResultInterface` and objects
+    stored as relation in another object as
+    :php-short:`\TYPO3\CMS\Extbase\Persistence\ObjectStorage`.
+
+..  _typo3-fluid-form-select-usage-models-optionLabelField:
+
+optionLabelField: Define another property of the model for the option label
+---------------------------------------------------------------------------
+
+If the model to be displayed has no :php:`__toString()` method or you want to
+display the content of a different field, use option
+:ref:`optionLabelField <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-form-selectviewhelper-optionlabelfield>`
+
+..  code-block:: html
+
+    <f:form.select name="payment" value="{myPayment}"
+        options="{paymentOptions}" optionLabelField="someLabel"/>
+
+The :ref:`options <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-form-selectviewhelper-options>`
+may contain an array or anything else Traversable including
+
+..  _typo3-fluid-form-select-usage-models-optionValueField:
+
+optionValueField: Define another property of the model as value
+---------------------------------------------------------------
+
+If you are dealing with non-persisted models or Data-Transfer-Objects there is
+no valid identifier that could be used to automatically map the users selection
+in your controller. In this case you must provide the name of the field to
+be used to identify the object:
+
+..  code-block:: html
+
+    <f:form.select name="payment" value="{myPayment}"
+        options="{paymentOptions}" optionValueField="paymentIdentifier"/>
+
+The controller action will then be called with the content of that field:
+
+..  code-block:: html
+
+    // Variable $payment contains the paymentIdentifier from the model
+    public function selectPaymentAction(String $payment): ResponseInterface
+
+..  _typo3-fluid-form-select-usage-propery:
+
+Binding the select field to an object property
+==============================================
+
+When the surrounding `<f:form>` uses `Property mapping <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-form-example-property>`_
+we can also map the selected option to the model:
+
+..  tabs::
+
+    ..  group-tab:: Fluid
+
+        ..  literalinclude:: _codesnippets/_SelectPaymentProperty.html
+            :caption: packages/my_extension/Resources/Private/Templates/User/PaymentForm.html
+
+    ..  group-tab:: User Model
+
+        The user model could have the following fields
+
+        ..  literalinclude:: _codesnippets/_SelectPaymentUser.php
+            :caption: packages/my_extension/Classes/Domain/Model/User.php
+
+    ..  group-tab:: Controller
+
+        The controller action will then be called with the user object:
+
+        ..  code-block:: php
+
+            public function selectPreferredPaymentAction(User $user): ResponseInterface
+
+..  _typo3-fluid-form-select-subviewHelper:
+
+Working with options and option groups
+======================================
+
+..  _typo3-fluid-form-select-option:
+
+Form.select.option ViewHelper `<f:form.select.option>`
+------------------------------------------------------
+
+..  typo3:viewhelper:: form.select.option
+    :source: /Global.json
+    :display: tags,description,gitHubLink
+    :noindex:
+
+The `<f:form.select.option>` ViewHelper can be used to create a completely
+`<f:form.select.option>` :html:`<option>`  tags in a way compatible with the
 HMAC generation.
-To do so, leave out the ``options`` argument and use child ViewHelpers:
+To do so, leave out the `options` argument and use child ViewHelpers:
 
-Custom options and optgroup::
+..  code-block:: html
 
-   <f:form.select name="myproperty">
+    <f:form.select name="myproperty">
       <f:form.select.option value="1">Option one</f:form.select.option>
-      <f:form.select.option value="2">Option two</f:form.select.option>
-      <f:form.select.optgroup>
-         <f:form.select.option value="3">Grouped option one</f:form.select.option>
-         <f:form.select.option value="4">Grouped option twi</f:form.select.option>
-      </f:form.select.optgroup>
-   </f:form.select>
+      <f:form.select.option value="2" selected="1">Option two</f:form.select.option>
+    </f:form.select>
 
-.. note::
-   Do not use vanilla :html:`<option>` or :html:`<optgroup>` tags!
-   They will invalidate the HMAC generation!
+..  note::
+    Do not use HTML :html:`<option>` tags!
+    They will invalidate the HMAC generation!
 
-Usage on domain objects
------------------------
+..  _typo3-fluid-form-select-optgroup:
 
-If you want to output domain objects, you can just pass them as array into the ``options`` parameter.
-To define what domain object value should be used as option key, use the ``optionValueField`` variable. Same goes for ``optionLabelField``.
-If neither is given, the Identifier (UID/uid) and the :php:`__toString()` method are tried as fallbacks.
+Form.select.optgroup ViewHelper `<f:form.select.optgroup>`
+----------------------------------------------------------
 
-If the ``optionValueField`` variable is set, the getter named after that value is used to retrieve the option key.
-If the ``optionLabelField`` variable is set, the getter named after that value is used to retrieve the option value.
+..  typo3:viewhelper:: form.select.optgroup
+    :source: /Global.json
+    :display: tags,description,gitHubLink
+    :noindex:
 
-If the ``prependOptionLabel`` variable is set, an option item is added in first position, bearing an empty string or -
-if provided, the value of the ``prependOptionValue`` variable as value.
+The `<f:form.select.option>` can be grouped with the `<f:form.select.optgroup>`
+to produce :html:`<optgroup>` in the HTML output.
 
-Domain objects::
+..  code-block:: html
 
-   <f:form.select name="users" options="{userArray}" optionValueField="id" optionLabelField="firstName" />
+    <f:form.select name="myproperty">
+       <f:form.select.option value="1">Option one</f:form.select.option>
+       <f:form.select.option value="2">Option two</f:form.select.option>
+       <f:form.select.optgroup>
+          <f:form.select.option value="3">Grouped option one</f:form.select.option>
+          <f:form.select.option value="4">Grouped option twi</f:form.select.option>
+       </f:form.select.optgroup>
+    </f:form.select>
 
-In the above example, the ``userArray`` is an array of "User" domain objects, with no array key specified.
+..  _typo3-fluid-form-select-option-placeholder:
 
-So, in the above example, the method :php:`$user->getId()` is called to
-retrieve the key, and :php:`$user->getFirstName()` to retrieve the displayed
-value of each entry.
+Please select option placeholder
+================================
 
-The ``value`` property now expects a domain object, and tests for object equivalence.
+In HTML the :html:`<select>` element always selects the first option if nothing
+else is selected. If the field is mandatory and the user should be forced to
+make a selection or if an empty value should be possible, you need an empty
+option as first option. You can use argument
+:ref:`prependOptionLabel <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-form-selectviewhelper-prependoptionlabel>`
+to set a label for this object. The value of the option will be an empty string.
+If you need another value, for example 0 because you are expecting an integer,
+you can use
+:ref:`prependOptionValue <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-form-selectviewhelper-prependoptionvalue>`.
+
+..  code-block:: html
+
+    <f:form.select options="{user.availablePaymentOptions}"
+                   property="preferredPayment"
+                   prependOptionLabel="Ask me every time!"
+                   prependOptionValue="ask"
+    />
+
+You can achieve the same effect by combining  the
+:ref:`options <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-form-selectviewhelper-options>`
+argument with one (or several)
+`<form.select.option> <f:form.select.option> <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-form-select-option>`_:
+
+..  code-block:: html
+
+    <f:form.select options="{user.availablePaymentOptions}"
+                   property="preferredPayment"
+                   optionsAfterContent="true"
+                   required="1"
+    >
+       <f:form.select.option value="">Please Chose *</f:form.select.option>
+       <f:form.select.option value="ask">Ask me every time!</f:form.select.option>
+    </f:form.select>
+
+It is possible to put the additional options last and combine the two:
+
+..  code-block:: html
+
+    <f:form.select options="{user.availablePaymentOptions}"
+                   property="preferredPayment"
+                   prependOptionLabel="Please Chose *"
+                   required="1"
+    >
+       <f:form.select.option value="ask">Ask me every time!</f:form.select.option>
+    </f:form.select>
+
+..  _typo3-fluid-form-select-arguments:
+
+Arguments of the Form.select ViewHelper
+=======================================
+
+..  include:: /_Includes/_ArbitraryArguments.rst.txt
+
+..  typo3:viewhelper:: form.select
+    :source: /Global.json
+    :display: arguments-only
+
+..  _typo3-fluid-form-select-option-arguments:
+
+Arguments of the Form.select.option ViewHelper
+==============================================
+
+..  include:: /_Includes/_ArbitraryArguments.rst.txt
+
+..  typo3:viewhelper:: form.select.option
+    :source: /Global.json
+    :display: arguments-only
+
+..  _typo3-fluid-form-select-optgroup-arguments:
+
+Arguments of the Form.select.optgroup ViewHelper
+================================================
+
+..  include:: /_Includes/_ArbitraryArguments.rst.txt
+
+..  typo3:viewhelper:: form.select.optgroup
+    :source: /Global.json
+    :display: arguments-only

--- a/Documentation/Global/Form/Select.rst
+++ b/Documentation/Global/Form/Select.rst
@@ -103,7 +103,7 @@ and in an Extbase model:
 When the form gets submitted, the UID of the chosen model appears in the request
 data. Extbase will then map that uid back to the model for you.
 
-The ViewHelper will then use the model's UID as data submitted in the from and
+The ViewHelper will then use the model's UID as data submitted in the form and
 the result of method :php:`__toString()` as display text.
 
 ..  note::

--- a/Documentation/Global/Form/Select.rst
+++ b/Documentation/Global/Form/Select.rst
@@ -37,7 +37,7 @@ human-readable name.
 
     ..  group-tab:: Controller
 
-        The argument for will have the key of the chosen entry as value.
+        The argument will have the key of the chosen entry as value.
 
         ..  literalinclude:: _codesnippets/_SelectGender.php
             :caption: packages/my_extension/Classes/Controller/UserController.php
@@ -64,7 +64,7 @@ array with the options to the view:
         ..  literalinclude:: _codesnippets/_SelectPayment.php
             :caption: packages/my_extension/Classes/Controller/UserController.php
 
-To pre select a value, use the argument
+To pre-select a value, use the argument
 :ref:`value <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-form-selectviewhelper-value>`.
 
 ..  _typo3-fluid-form-select-usage-models:
@@ -85,7 +85,7 @@ and in an Extbase model:
 
     ..  group-tab:: Controller
 
-        In the controller we can get all payment methods from the from the
+        In the controller we can get all payment methods from the
         `Repository <https://docs.typo3.org/permalink/t3coreapi:extbase-repository>`_
         now and pass it to the view as variable:
 
@@ -103,7 +103,7 @@ and in an Extbase model:
 When the form gets submitted, the UID of the chosen model appears in the request
 data. Extbase will then map that uid back to the model for you.
 
-The ViewHelper will then use the models UID as data submitted in the from and
+The ViewHelper will then use the model's UID as data submitted in the from and
 the result of method :php:`__toString()` as display text.
 
 ..  note::
@@ -130,16 +130,16 @@ display the content of a different field, use option
         options="{paymentOptions}" optionLabelField="someLabel"/>
 
 The :ref:`options <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-form-selectviewhelper-options>`
-may contain an array or anything else Traversable including
+may contain an array or anything else `Traversable` including
 
 ..  _typo3-fluid-form-select-usage-models-optionValueField:
 
 optionValueField: Define another property of the model as value
 ---------------------------------------------------------------
 
-If you are dealing with non-persisted models or Data-Transfer-Objects there is
-no valid identifier that could be used to automatically map the users selection
-in your controller. In this case you must provide the name of the field to
+If you are dealing with non-persisted models or Data-Transfer-Objects (DTO) there is
+no valid identifier that could be used to automatically map the user's selection
+in your controller. In this case, you must provide the name of the field to
 be used to identify the object:
 
 ..  code-block:: html
@@ -241,13 +241,13 @@ to produce :html:`<optgroup>` in the HTML output.
 
 ..  _typo3-fluid-form-select-option-placeholder:
 
-Please select option placeholder
+Using an "Please select an option" placeholder
 ================================
 
-In HTML the :html:`<select>` element always selects the first option if nothing
+In HTML, the :html:`<select>` element always selects the first option, if nothing
 else is selected. If the field is mandatory and the user should be forced to
 make a selection or if an empty value should be possible, you need an empty
-option as first option. You can use argument
+option as first option. You can use the argument
 :ref:`prependOptionLabel <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-form-selectviewhelper-prependoptionlabel>`
 to set a label for this object. The value of the option will be an empty string.
 If you need another value, for example 0 because you are expecting an integer,

--- a/Documentation/Global/Form/Select/Index.rst
+++ b/Documentation/Global/Form/Select/Index.rst
@@ -1,13 +1,3 @@
-..  include:: /Includes.rst.txt
+:orphan:
 
-======
-Select
-======
-
-
-..  toctree::
-    :titlesonly:
-    :glob:
-
-    */Index
-    *
+See: :ref:`typo3-fluid-form-select`.

--- a/Documentation/Global/Form/Select/Optgroup.rst
+++ b/Documentation/Global/Form/Select/Optgroup.rst
@@ -1,11 +1,3 @@
-:navigation-title: form.select.optgroup
+:orphan:
 
-..  include:: /Includes.rst.txt
-..  _typo3-fluid-form-select-optgroup:
-
-==========================================================
-Form.select.optgroup ViewHelper `<f:form.select.optgroup>`
-==========================================================
-
-..  typo3:viewhelper:: form.select.optgroup
-    :source: ../../../Global.json
+See: :ref:`typo3-fluid-form-select-optgroup`.

--- a/Documentation/Global/Form/Select/Option.rst
+++ b/Documentation/Global/Form/Select/Option.rst
@@ -1,11 +1,3 @@
-:navigation-title: form.select.option
+:orphan:
 
-..  include:: /Includes.rst.txt
-..  _typo3-fluid-form-select-option:
-
-======================================================
-Form.select.option ViewHelper `<f:form.select.option>`
-======================================================
-
-..  typo3:viewhelper:: form.select.option
-    :source: ../../../Global.json
+See :ref:`typo3-fluid-form-select-option`.

--- a/Documentation/Global/Form/_codesnippets/_SelectGender.html
+++ b/Documentation/Global/Form/_codesnippets/_SelectGender.html
@@ -1,0 +1,4 @@
+<f:form action="selectGender">
+    <f:form.select name="gender" options="{1: 'female', 2: 'male', 3: 'diverse'}" />
+    <f:form.submit value="Submit"/>
+</f:form>

--- a/Documentation/Global/Form/_codesnippets/_SelectGender.php
+++ b/Documentation/Global/Form/_codesnippets/_SelectGender.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Controller;
+
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+class UserController extends ActionController
+{
+    public function genderFormAction(): ResponseInterface
+    {
+        return $this->htmlResponse();
+    }
+    public function selectGenderAction(int $gender): ResponseInterface
+    {
+        // do something
+        return $this->redirect('show');
+    }
+}

--- a/Documentation/Global/Form/_codesnippets/_SelectPayment.html
+++ b/Documentation/Global/Form/_codesnippets/_SelectPayment.html
@@ -1,0 +1,4 @@
+<f:form action="selectPayment">
+    <f:form.select name="payment" options="{paymentOptions}" value="{myPayment}" />
+    <f:form.submit value="Submit"/>
+</f:form>

--- a/Documentation/Global/Form/_codesnippets/_SelectPayment.php
+++ b/Documentation/Global/Form/_codesnippets/_SelectPayment.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Controller;
+
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+class UserController extends ActionController
+{
+    public function paymentFormAction(): ResponseInterface
+    {
+        $paymentOptions =
+            ['payPal' => 'PayPal International Services', 'visa' => 'VISA Card'];
+        $this->view->assign('paymentOptions', $paymentOptions);
+        $this->view->assign('myPayment', 'visa');
+        return $this->htmlResponse();
+    }
+    public function selectPaymentAction(string $payment): ResponseInterface
+    {
+        // do something
+        return $this->redirect('show');
+    }
+}

--- a/Documentation/Global/Form/_codesnippets/_SelectPaymentMethod.php
+++ b/Documentation/Global/Form/_codesnippets/_SelectPaymentMethod.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Domain\Model;
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+
+class PaymentMethod extends AbstractEntity implements \Stringable
+{
+    protected string $title;
+    protected string $paymentIdentifier;
+
+    // Getters and setters
+
+    // If the model implement the __toString() method
+    // The result of that method is displayed in the select form
+    public function __toString(): string
+    {
+        return $this->title;
+    }
+}

--- a/Documentation/Global/Form/_codesnippets/_SelectPaymentModelController.php
+++ b/Documentation/Global/Form/_codesnippets/_SelectPaymentModelController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Controller;
+
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+class UserController extends ActionController
+{
+    public function __construct(
+        protected readonly PaymentMethodRepository $paymentMethodRepository,
+    ) {}
+
+    public function paymentFormAction(): ResponseInterface
+    {
+        $paymentOptions = $this->paymentMethodRepository->findAll();
+        $this->view->assign('paymentOptions', $paymentOptions);
+        $this->view->assign('myPayment', 'visa');
+        return $this->htmlResponse();
+    }
+    public function selectPaymentAction(PaymentMethod $payment): ResponseInterface
+    {
+        // do something
+        return $this->redirect('show');
+    }
+}

--- a/Documentation/Global/Form/_codesnippets/_SelectPaymentProperty.html
+++ b/Documentation/Global/Form/_codesnippets/_SelectPaymentProperty.html
@@ -1,0 +1,6 @@
+<f:form action="selectPreferredPayment" object="{user}" objectName="user">
+    <f:form.select options="{user.availablePaymentOptions}"
+                   property="preferredPayment"
+    />
+    <f:form.submit value="Submit"/>
+</f:form>

--- a/Documentation/Global/Form/_codesnippets/_SelectPaymentUser.php
+++ b/Documentation/Global/Form/_codesnippets/_SelectPaymentUser.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Controller;
+
+use MyVendor\MyExtension\Domain\Model\PaymentMethod;
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+
+class User extends AbstractEntity
+{
+    //Other fields
+    protected ?PaymentMethod $preferredPayment;
+    /** @var ObjectStorage<PaymentMethod>  */
+    protected ObjectStorage $availablePaymentOptions;
+
+    // initialize method, getters and setters
+}


### PR DESCRIPTION
* Demonstrate different definitions for options
* Demonstrate binding options to models
* Demonstrate binding options to Dtos
* Demonstrate property mapping

Display subviewhelpers Form.select.option and Form.select.optgroup on the same page as they cannot be used standalone

Releases: main, 13.4