### PR TITLE
[TASK] Update f:form.hidden ViewHelper page

### DIFF
--- a/Documentation/Global/Form/Hidden.rst
+++ b/Documentation/Global/Form/Hidden.rst
@@ -8,21 +8,90 @@ Form.hidden ViewHelper `<f:form.hidden>`
 ========================================
 
 ..  typo3:viewhelper:: form.hidden
-    :source: ../../Global.json
-    :display: tags,description,gitHubLink,arguments
+    :source: /Global.json
+    :display: tags,description,gitHubLink
+    :noindex:
+
+..  contents:: Table of contents
 
 ..  _typo3-fluid-form-hidden-example:
 
-Examples
-========
+Hidden field bound to a controller argument
+===========================================
 
-Example::
+Hidden fields can be used to pass additional arguments to a controller action.
 
-   <f:form.hidden name="myHiddenValue" value="42" />
+..  tabs::
 
-Output::
+    ..  group-tab:: Fluid
 
-   <input type="hidden" name="myHiddenValue" value="42" />
+        The form includes a hidden field to pass the blog post UID:
 
-You can also use the "property" attribute if you have bound an object to the form.
-See :ref:`<f:form> <typo3-fluid-form>` for more documentation.
+        ..  literalinclude:: _codesnippets/_hiddenComment.html
+            :caption: packages/my_extension/Resources/Private/Templates/Comment/Form.html
+
+    ..  group-tab:: Controller
+
+        The controller action can then look like this:
+
+        ..  literalinclude:: _codesnippets/_CheckboxController.php
+            :caption: packages/my_extension/Classes/Controller/CommentController.php
+
+..  tip::
+    In a `<f:form>` with the :ref:`method
+    <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-formviewhelper-method>`
+    set to `post`, the content of hidden fields is sent in the POST body.
+    This is ideal for data that should not be visible in the URL or is too
+    large to include in the query string.
+
+
+..  _typo3-fluid-form-hidden-example-property:
+
+Use case: Creating a comment for a specific blog post
+=====================================================
+
+You have:
+
+*   A `Comment` domain model that relates to a `BlogPost`
+*   A `BlogPost` detail page that includes a comment form
+*   The property `blogPost` is set automatically and not selectable by the user
+
+..  tabs::
+
+    ..  group-tab:: Fluid
+
+        ..  literalinclude:: _codesnippets/_hiddenCommentPost.html
+            :caption: packages/my_extension/Resources/Private/Templates/Comment/CreateForm.html
+
+    ..  group-tab:: Model
+
+        The domain model includes a relation to the BlogPost entity:
+
+        ..  literalinclude:: _codesnippets/_HiddenCommentPostModel.php
+            :caption: packages/my_extension/Classes/Domain/Model/Comment.php
+
+    ..  group-tab:: Controller
+
+        The controller saves the comment and redirects to the related blog post:
+
+        ..  literalinclude:: _codesnippets/_HiddenCommentPostController.php
+            :caption: packages/my_extension/Classes/Controller/CommentController.php
+
+..  tip::
+
+    Use a hidden field to bind a new object (like a `Comment`) to its parent
+    (like a `BlogPost`). This keeps the relation intact without exposing
+    it in the user interface.
+
+    In this example, the `blogPost` property is set via a hidden input and
+    automatically mapped back to a domain object using Extbase's property
+    mapping.
+
+..  _typo3-fluid-form-hidden-example-arguments:
+
+Arguments of the form hidden ViewHelper
+=======================================
+
+..  typo3:viewhelper:: form.hidden
+    :source: /Global.json
+    :display: arguments-only

--- a/Documentation/Global/Form/_codesnippets/_HiddenCommentController.php
+++ b/Documentation/Global/Form/_codesnippets/_HiddenCommentController.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Vendor\Extension\Controller;

--- a/Documentation/Global/Form/_codesnippets/_HiddenCommentController.php
+++ b/Documentation/Global/Form/_codesnippets/_HiddenCommentController.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Vendor\Extension\Controller;
+
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+class CommentController extends ActionController
+{
+    public function saveAction(string $message, ?string $commentId = null): ResponseInterface
+    {
+        if ($commentId === null) {
+            // Create new comment
+            $this->addFlashMessage('Created a new comment');
+        } else {
+            // Fetch and update an existing comment
+            $this->addFlashMessage('Updated comment with ID ' . $commentId);
+        }
+        return $this->redirect('list');
+    }
+}

--- a/Documentation/Global/Form/_codesnippets/_HiddenCommentPostController.php
+++ b/Documentation/Global/Form/_codesnippets/_HiddenCommentPostController.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MyVendor\MyExtension\Controller;

--- a/Documentation/Global/Form/_codesnippets/_HiddenCommentPostController.php
+++ b/Documentation/Global/Form/_codesnippets/_HiddenCommentPostController.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Controller;
+
+use MyVendor\MyExtension\Domain\Model\Comment;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+class CommentController extends ActionController
+{
+    public function createAction(Comment $comment): ResponseInterface
+    {
+        // $comment->getBlogPost() returns the associated BlogPost object
+        $this->commentRepository->add($comment);
+        $this->addFlashMessage('Your comment was submitted!');
+        return $this->redirect('show', 'BlogPost', null, ['blogPost' => $comment->getBlogPost()]);
+    }
+}

--- a/Documentation/Global/Form/_codesnippets/_HiddenCommentPostModel.php
+++ b/Documentation/Global/Form/_codesnippets/_HiddenCommentPostModel.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MyVendor\MyExtension\Domain\Model;

--- a/Documentation/Global/Form/_codesnippets/_HiddenCommentPostModel.php
+++ b/Documentation/Global/Form/_codesnippets/_HiddenCommentPostModel.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Domain\Model;
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+
+class Comment extends AbstractEntity
+{
+    protected string $authorName = '';
+    protected string $content = '';
+    protected BlogPost $blogPost;
+
+    // Getters and setters...
+}

--- a/Documentation/Global/Form/_codesnippets/_hiddenComment.html
+++ b/Documentation/Global/Form/_codesnippets/_hiddenComment.html
@@ -1,0 +1,5 @@
+<f:form action="save" controller="Comment" method="post">
+    <f:form.hidden name="commentId" value="{comment.id}" />
+    <f:form.textfield name="message" value="{comment.message}" />
+    <f:form.submit value="Save" />
+</f:form>

--- a/Documentation/Global/Form/_codesnippets/_hiddenCommentPost.html
+++ b/Documentation/Global/Form/_codesnippets/_hiddenCommentPost.html
@@ -1,0 +1,6 @@
+<f:form action="create" controller="Comment" method="post" object="{comment}">
+    <f:form.hidden property="blogPost" value="{blogPost.uid}" />
+    <f:form.textfield property="authorName" />
+    <f:form.textarea property="content" />
+    <f:form.submit value="Submit Comment" />
+</f:form>


### PR DESCRIPTION
* Explain usage of hidden fields to pass controller arguments
* Add real-world use case: comment form bound to blog post
* Demonstrate property binding and automatic object mapping

Releases: main, 13.4