### PR TITLE
[FEATURE] Add f:form.textarea ViewHelper examples

### DIFF
--- a/Documentation/Global/Form/Textarea.rst
+++ b/Documentation/Global/Form/Textarea.rst
@@ -9,17 +9,91 @@ Form.textarea ViewHelper `<f:form.textarea>`
 
 ..  typo3:viewhelper:: form.textarea
     :source: ../../Global.json
-    :display: tags,description,gitHubLink,arguments
+    :display: tags,description,gitHubLink
+    :noindex:
+
+..  contents:: Table of contents
+
+..  warning::
+    User input, especially from free text fields, may contain harmful content.
+    Sanitize all input data and prevent
+    `Cross-site scripting (XSS) <https://docs.typo3.org/permalink/t3coreapi:security-xss>`_.
+
+    Also consider if `SQL injection <https://docs.typo3.org/permalink/t3coreapi:security-sql-injection>`_
+    is possible.
 
 ..  _typo3-fluid-form-textarea-example:
 
-Examples
-========
+A basic text area bound to an action argument
+=============================================
 
-Example::
+This example shows how to bind a textarea to an Extbase controller action
+argument.
 
-   <f:form.textarea name="myTextArea" value="This is shown inside the textarea" />
+This approach is appropriate when you want to handle input directly in a
+controller action, without relying on a domain model or Data Transfer Object (DTO).
 
-Output::
+..  tabs::
 
-   <textarea name="myTextArea">This is shown inside the textarea</textarea>
+    ..  group-tab:: Fluid
+
+        ..  literalinclude:: _codesnippets/_TextfieldSimple.html
+            :caption: packages/my_extension/Resources/Private/Templates/Contact/ShowForm.html
+
+    ..  group-tab:: Controller
+
+        The controller action can then look like this:
+
+        ..  literalinclude:: _codesnippets/_TextfieldSimpleController.php
+            :caption: packages/my_extension/Classes/Controller/ContactController.php
+
+..  _typo3-fluid-form-textarea-example-property:
+
+Property binding: A text area bound to a model property
+=======================================================
+
+Using the :ref:`property <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-form-textfieldviewhelper-property>`
+argument, a text field can be bound to the property of an
+`Extbase model <https://docs.typo3.org/permalink/t3coreapi:extbase-model>`_.
+
+For this, the surrounding form must also define the
+:ref:`object <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-formviewhelper-object>`
+property. As the textarea ViewHelper may provide texts longer than 255 chars,
+the TCA for the field should be of type `Text areas & RTE <https://docs.typo3.org/permalink/t3tca:columns-text>`_.
+This ensures that the auto-generated database field will also be of type :sql:`TEXT`,
+which is suitable for longer content.”
+
+..  tabs::
+
+    ..  group-tab:: Fluid
+
+        ..  literalinclude:: _codesnippets/_CommentForm.html
+            :caption: packages/my_extension/Resources/Private/Templates/Blog/Comment.html
+
+    ..  group-tab:: Controller
+
+        The controller action can then look like this:
+
+        ..  literalinclude:: _codesnippets/_CommentController.php
+            :caption: packages/my_extension/Classes/Controller/CommentController.php
+
+    ..  group-tab:: Model
+
+        ..  literalinclude:: _codesnippets/_Comment.php
+            :caption: packages/my_extension/Classes/Domain/Model/Comment.php
+
+    ..  group-tab:: TCA Configuration
+
+        ..  literalinclude:: _codesnippets/_comment_tca.php
+            :caption: packages/my_extension/Configuration/TCA/tx_myextension_domain_model_comment.php
+
+        ..  _typo3-fluid-form-textarea-arguments:
+
+Arguments of the textarea form field ViewHelper
+===============================================
+
+..  include:: /_Includes/_ArbitraryArguments.rst.txt
+
+..  typo3:viewhelper:: form.textarea
+    :source: /Global.json
+    :display: arguments-only

--- a/Documentation/Global/Form/_codesnippets/_TextfieldSimple.html
+++ b/Documentation/Global/Form/_codesnippets/_TextfieldSimple.html
@@ -1,0 +1,14 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+<f:form action="sendMessage" controller="Contact" method="post">
+
+    <label for="tx-contact-name">Your Name:</label>
+    <f:form.textfield name="name" id="tx-contact-name" required="true" />
+    <label for="tx-contact-message">Message:</label>
+    <f:form.textarea name="message" id="tx-contact-message" required="true" />
+
+    <f:form.submit class="button" value="Send" />
+</f:form>
+
+</html>

--- a/Documentation/Global/Form/_codesnippets/_TextfieldSimpleController.php
+++ b/Documentation/Global/Form/_codesnippets/_TextfieldSimpleController.php
@@ -1,14 +1,18 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-      data-namespace-typo3-fluid="true">
+<?php
+declare(strict_types=1);
 
-<f:form action="sendMessage" controller="Contact" method="post">
+namespace MyVendor\MyExtension\Controller;
 
-    <label for="tx-contact-name">Your Name:</label>
-    <f:form.textfield name="name" id="tx-contact-name" required="true" />
-    <label for="tx-contact-message">Message:</label>
-    <f:form.textarea name="message" id="tx-contact-message" required="true" />
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
-    <f:form.submit class="button" value="Send" />
-</f:form>
-
-</html>
+class ContactController extends ActionController
+{
+    public function sendMessageAction(string $name, string $message): ResponseInterface
+    {
+        // Process data
+        $this->addFlashMessage('Your message was received.');
+        return $this->redirect('showForm');
+    }
+    // ...
+}

--- a/Documentation/Global/Form/_codesnippets/_TextfieldSimpleController.php
+++ b/Documentation/Global/Form/_codesnippets/_TextfieldSimpleController.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MyVendor\MyExtension\Controller;

--- a/Documentation/Global/Form/_codesnippets/_TextfieldSimpleController.php
+++ b/Documentation/Global/Form/_codesnippets/_TextfieldSimpleController.php
@@ -1,0 +1,14 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+<f:form action="sendMessage" controller="Contact" method="post">
+
+    <label for="tx-contact-name">Your Name:</label>
+    <f:form.textfield name="name" id="tx-contact-name" required="true" />
+    <label for="tx-contact-message">Message:</label>
+    <f:form.textarea name="message" id="tx-contact-message" required="true" />
+
+    <f:form.submit class="button" value="Send" />
+</f:form>
+
+</html>

--- a/Documentation/Global/Form/_codesnippets/_comment_tca.php
+++ b/Documentation/Global/Form/_codesnippets/_comment_tca.php
@@ -19,7 +19,7 @@ return [
         'content' => [
             'label' => 'Message',
             'config' => [
-                'type' => 'text'
+                'type' => 'text',
             ],
         ],
     ],

--- a/Documentation/Global/Form/_codesnippets/_comment_tca.php
+++ b/Documentation/Global/Form/_codesnippets/_comment_tca.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+    'ctrl' => [
+        'title' => 'Comment',
+        'label' => 'email',
+        // ...
+    ],
+    'types' => [
+        '1' => ['showitem' => 'email, content'],
+    ],
+    'columns' => [
+        'email' => [
+            'label' => 'Email',
+            'config' => [
+                'type' => 'email',
+            ],
+        ],
+        'content' => [
+            'label' => 'Message',
+            'config' => [
+                'type' => 'text'
+            ],
+        ],
+    ],
+];


### PR DESCRIPTION
* Document usage of <f:form.textarea> in Fluid templates
* Provide examples for both controller argument and property binding
* Include tabs with Fluid, Controller, Model, and TCA code snippets
* Highlight security considerations (e.g., XSS, SQL injection)
* Structure content for alignment with other ViewHelper docs

Releases: main, 13.4