### PR TITLE
[TASK] Update f:form.button ViewHelper page

### DIFF
--- a/Documentation/Global/Form/Button.rst
+++ b/Documentation/Global/Form/Button.rst
@@ -7,32 +7,140 @@
 Form.button ViewHelper `<f:form.button>`
 ========================================
 
+This ViewHelper creates an :html:`<button>` HTML element within the
+`Form ViewHelper <f:form> <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-form>`_.
+
+Unlike the `Form.submit ViewHelper <f:form.submit> <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-form-submit>`_,
+the Form.button ViewHelper can contain HTML content — for example, an icon.
+
+By using the :ref:`type <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-form-buttonviewhelper-type>`
+argument, you can create button types other than `submit`, such as `button`
+or `reset`.
+
 ..  typo3:viewhelper:: form.button
-    :source: ../../Global.json
-    :display: tags,description,gitHubLink,arguments
+    :source: /Global.json
+    :display: tags,gitHubLink
+    :noindex:
+
+..  contents:: Table of contents
 
 ..  _typo3-fluid-form-button-example:
 
-Examples
-========
+A Fluid form with a submit button containing an icon
+====================================================
 
-Defaults::
+You can use the `<f:form.button>` ViewHelper within an Extbase
+form to render a `<button type="submit">` element that allows HTML content.
 
-   <f:form.button>Send Mail</f:form.button>
+This is especially useful when you want to include custom elements inside the button,
+such as icons or styled spans.
 
-Output::
+When the user clicks the button, the action specified by the surrounding
+`<f:form> <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-form>`_
+is triggered.
 
-   <button type="submit" name="" value="">Send Mail</button>
+..  tabs::
 
-Disabled cancel button with some HTML5 attributes::
+    ..  group-tab:: Fluid
 
-   <f:form.button type="reset" disabled="disabled"
-       name="buttonName" value="buttonValue"
-       formmethod="post" formnovalidate="formnovalidate"
-   >
-       Cancel
-   </f:form.button>
+        .. literalinclude:: _codesnippets/_FormSubmitButton.html
+            :caption: packages/my_extension/Resources/Private/Templates/Comment/Edit.html
 
-Output::
+    ..  group-tab:: Controller
 
-   <button disabled="disabled" formmethod="post" formnovalidate="formnovalidate" type="reset" name="myForm[buttonName]" value="buttonValue">Cancel</button>
+        You can use the same Extbase controller as in the example
+        `A Fluid form with a single submit button <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-form-submit-example>`_,
+        which uses the `<f:form.submit>` ViewHelper.
+
+        ..  literalinclude:: _codesnippets/_SubmitController.php
+            :caption: packages/my_extension/Classes/Controller/CommentController.php
+
+.. _typo3-fluid-form-button-multiple:
+
+A Fluid form with multiple buttons of different types
+=====================================================
+
+The `<f:form.button>` ViewHelper supports the `type` attribute, allowing you to
+render buttons of type `submit`, `reset`, or `button`. This is useful when you
+want to offer multiple actions within the same form, each with a distinct
+purpose and custom styling or icons.
+
+Unlike `<f:form.submit>`, you can include inline HTML (e.g. icons, spans) in each button.
+
+.. tabs::
+
+    ..  group-tab:: Fluid
+
+        .. literalinclude:: _codesnippets/_FormMultipleButtons.html
+            :caption: packages/my_extension/Resources/Private/Templates/Comment/Edit.html
+
+    ..  group-tab:: Controller
+
+        A single Extbase controller action can be used to differentiate the submitted action
+        based on the button name or value.
+
+        ..  literalinclude:: _codesnippets/_MultipleButtonsController.php
+            :caption: packages/my_extension/Classes/Controller/CommentController.php
+
+        ..  note::
+            The reset button does **not** submit the form and is not processed by the controller.
+            It resets all form fields to their initial values using standard HTML behavior
+            (`<button type="reset">`). Therefore, there is no need to handle it in the controller.
+
+..  note::
+    When using multiple buttons, you can assign different `name` and `value` attributes
+    to detect which button was clicked in the controller.
+
+..  _typo3-fluid-form-button-html5:
+
+A button with additional HTML5 attributes
+=========================================
+
+The `<f:form.button>` ViewHelper allows you to pass through standard HTML5
+button attributes such as `disabled`, `formmethod`, and `formnovalidate`.
+
+This is useful when you need more control over how the button behaves in relation to
+form submission and validation.
+
+..  literalinclude:: _codesnippets/_FormButtonHtml5Attributes.html
+    :caption: packages/my_extension/Resources/Private/Templates/Comment/Edit.html
+
+..  note::
+    You can use these attributes with any button type (`submit`, `reset`, or `button`) and
+    they will be passed through to the rendered `<button>` tag.
+
+.. _typo3-fluid-form-button-aria:
+
+A button with accessibility attributes
+======================================
+
+The `<f:form.button>` ViewHelper supports accessibility attributes like `aria-label`,
+`aria-disabled`, or `aria-describedby`.
+
+These attributes are passed directly to the rendered `<button>` tag, allowing you to make your forms
+more accessible for assistive technologies such as screen readers.
+
+For convenience, you can also use the
+:ref:`aria <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-form-buttonviewhelper-aria>`
+attribute and pass an array to it.
+
+Fluid will automatically generate the corresponding `aria-*` attributes
+based on the key-value pairs in the array.
+
+.. literalinclude:: _codesnippets/_FormButtonAria.html
+    :caption: packages/my_extension/Resources/Private/Templates/Comment/Edit.html
+
+..  note::
+    Combine visible labels with appropriate `ARIA <https://www.w3.org/WAI/ARIA/apg/>`_
+    attributes to improve the experience for users with screen readers.
+
+..  _typo3-fluid-form-button-arguments:
+
+Arguments of the form.button ViewHelper
+=======================================
+
+..  include:: /_Includes/_ArbitraryArguments.rst.txt
+
+..  typo3:viewhelper:: form.button
+    :source: /Global.json
+    :display: arguments-only

--- a/Documentation/Global/Form/Button.rst
+++ b/Documentation/Global/Form/Button.rst
@@ -7,7 +7,7 @@
 Form.button ViewHelper `<f:form.button>`
 ========================================
 
-This ViewHelper creates an :html:`<button>` HTML element within the
+This ViewHelper creates a :html:`<button>` HTML element within the
 `Form ViewHelper <f:form> <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-form>`_.
 
 Unlike the `Form.submit ViewHelper <f:form.submit> <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-form-submit>`_,

--- a/Documentation/Global/Form/Button.rst
+++ b/Documentation/Global/Form/Button.rst
@@ -43,7 +43,7 @@ is triggered.
 
     ..  group-tab:: Fluid
 
-        .. literalinclude:: _codesnippets/_FormSubmitButton.html
+        ..  literalinclude:: _codesnippets/_FormSubmitButton.html
             :caption: packages/my_extension/Resources/Private/Templates/Comment/Edit.html
 
     ..  group-tab:: Controller

--- a/Documentation/Global/Form/Button.rst
+++ b/Documentation/Global/Form/Button.rst
@@ -71,7 +71,7 @@ Unlike `<f:form.submit>`, you can include inline HTML (e.g. icons, spans) in eac
 
     ..  group-tab:: Fluid
 
-        .. literalinclude:: _codesnippets/_FormMultipleButtons.html
+        ..  literalinclude:: _codesnippets/_FormMultipleButtons.html
             :caption: packages/my_extension/Resources/Private/Templates/Comment/Edit.html
 
     ..  group-tab:: Controller

--- a/Documentation/Global/Form/Button.rst
+++ b/Documentation/Global/Form/Button.rst
@@ -55,7 +55,7 @@ is triggered.
         ..  literalinclude:: _codesnippets/_SubmitController.php
             :caption: packages/my_extension/Classes/Controller/CommentController.php
 
-.. _typo3-fluid-form-button-multiple:
+..  _typo3-fluid-form-button-multiple:
 
 A Fluid form with multiple buttons of different types
 =====================================================

--- a/Documentation/Global/Form/Button.rst
+++ b/Documentation/Global/Form/Button.rst
@@ -67,7 +67,7 @@ purpose and custom styling or icons.
 
 Unlike `<f:form.submit>`, you can include inline HTML (e.g. icons, spans) in each button.
 
-.. tabs::
+..  tabs::
 
     ..  group-tab:: Fluid
 
@@ -109,7 +109,7 @@ form submission and validation.
     You can use these attributes with any button type (`submit`, `reset`, or `button`) and
     they will be passed through to the rendered `<button>` tag.
 
-.. _typo3-fluid-form-button-aria:
+..  _typo3-fluid-form-button-aria:
 
 A button with accessibility attributes
 ======================================
@@ -127,7 +127,7 @@ attribute and pass an array to it.
 Fluid will automatically generate the corresponding `aria-*` attributes
 based on the key-value pairs in the array.
 
-.. literalinclude:: _codesnippets/_FormButtonAria.html
+..  literalinclude:: _codesnippets/_FormButtonAria.html
     :caption: packages/my_extension/Resources/Private/Templates/Comment/Edit.html
 
 ..  note::

--- a/Documentation/Global/Form/_codesnippets/_FormButtonAria.html
+++ b/Documentation/Global/Form/_codesnippets/_FormButtonAria.html
@@ -1,0 +1,14 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+<f:form action="submit" controller="Comment" object="{comment}" objectName="comment" method="post">
+    <label for="tx-comment-content">Message:</label>
+    <f:form.textarea property="content" id="tx-comment-content" rows="6" cols="50" />
+    <p id="commentHint" class="form-text">
+        Press the send button to submit your comment.
+    </p>
+
+    <f:form.button type="submit" aria="{label: 'Send comment', describedby: 'commentHint'}">
+        <i class="fa fa-paper-plane" aria-hidden="true"></i> Send
+    </f:form.button>
+</f:form>
+</html>

--- a/Documentation/Global/Form/_codesnippets/_FormButtonHtml5Attributes.html
+++ b/Documentation/Global/Form/_codesnippets/_FormButtonHtml5Attributes.html
@@ -1,0 +1,13 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+<f:form action="submit" controller="Comment" method="post">
+    <f:form.button type="reset"
+                   name="cancel"
+                   value="cancel"
+                   disabled="disabled"
+                   formmethod="post"
+                   formnovalidate="formnovalidate">
+        Cancel
+    </f:form.button>
+</f:form>
+</html>

--- a/Documentation/Global/Form/_codesnippets/_FormMultipleButtons.html
+++ b/Documentation/Global/Form/_codesnippets/_FormMultipleButtons.html
@@ -1,0 +1,19 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+<f:form action="submit" controller="Comment" object="{comment}" objectName="comment" method="post">
+    <label for="tx-comment-content">Message:</label>
+    <f:form.textarea property="content" id="tx-comment-content" rows="6" cols="50" />
+
+    <f:form.button type="submit" name="action" value="save">
+        <i class="fa fa-save" aria-hidden="true"></i> Save
+    </f:form.button>
+
+    <f:form.button type="reset">
+        <i class="fa fa-undo" aria-hidden="true"></i> Reset
+    </f:form.button>
+
+    <f:form.button type="button" name="preview" value="1" onclick="alert('Preview not implemented!')">
+        <i class="fa fa-eye" aria-hidden="true"></i> Preview
+    </f:form.button>
+</f:form>
+</html>

--- a/Documentation/Global/Form/_codesnippets/_FormSubmitButton.html
+++ b/Documentation/Global/Form/_codesnippets/_FormSubmitButton.html
@@ -1,0 +1,11 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+<f:form action="submit" controller="Comment" objectName="comment" object="{comment}" method="post">
+    <label for="tx-blogexample-content">Message:</label>
+    <f:form.textarea property="content" id="tx-blogexample-content" rows="8" cols="46" />
+
+    <f:form.button>
+        <i class="fa fa-paper-plane"></i> Submit
+    </f:form.button>
+</f:form>
+</html>

--- a/Documentation/Global/Form/_codesnippets/_MultipleButtonsController.php
+++ b/Documentation/Global/Form/_codesnippets/_MultipleButtonsController.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Vendor\MyExtension\Controller;
 
+use MyVendor\MyExtension\Domain\Model\Comment;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
-use MyVendor\MyExtension\Domain\Model\Comment;
 
 class CommentController extends ActionController
 {

--- a/Documentation/Global/Form/_codesnippets/_MultipleButtonsController.php
+++ b/Documentation/Global/Form/_codesnippets/_MultipleButtonsController.php
@@ -1,0 +1,29 @@
+<?php
+namespace Vendor\MyExtension\Controller;
+
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use MyVendor\MyExtension\Domain\Model\Comment;
+
+class CommentController extends ActionController
+{
+    public function submitAction(Comment $comment, string $action): ResponseInterface
+    {
+        switch ($action) {
+            case 'save':
+                // Save logic here
+                $this->addFlashMessage('Comment saved!');
+                return $this->redirect('edit');
+
+            case 'preview':
+                // Assign preview-related data and render the same view
+                $this->view->assign('preview', true);
+                $this->view->assign('comment', $comment);
+                return $this->htmlResponse();
+
+            default:
+                $this->addFlashMessage('Unknown action');
+                return $this->redirect('edit');
+        }
+    }
+}


### PR DESCRIPTION
* Rewrite introduction and clarify difference from f:form.submit
* Add example: button with icon using inline HTML
* Demonstrate multiple buttons with different types and actions
* Add example with HTML5 attributes (disabled, formnovalidate)
* Show how to use ARIA attributes for accessibility
* Explain and demonstrate the `aria` ViewHelper argument with array syntax

Releases: main, 13.4