### PR TITLE
exclude JSON files from whitespace pro-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,6 @@ repos:
     rev: v4.4.0  # Use the latest version
     hooks:
       - id: trailing-whitespace
+        exclude: \.json$
       - id: end-of-file-fixer
+        exclude: \.json$


### PR DESCRIPTION
Not tested until now, but should work like explained here:

https://pre-commit.com/#config-exclude