### PR TITLE
[TASK] Improve <f:image> ViewHelper documentation

### DIFF
--- a/Documentation/Global/Image.rst
+++ b/Documentation/Global/Image.rst
@@ -91,10 +91,11 @@ The `<f:image>` ViewHelper generates a HTML `<img>` tag with the correct paths e
 Images from Extbase models in Fluid
 -----------------------------------
 
-In Extbase models you can use fields of type
-:php:`\TYPO3\CMS\Extbase\Domain\Model\FileReference` if a field may contain
-maximal one image and :php:`\TYPO3\CMS\Extbase\Persistence\ObjectStorage` if a
-field may contain several images. They can then be displayed using the
+In Extbase models you can use fields of type :php:`\TYPO3\CMS\Extbase\Persistence\ObjectStorage` with 
+the TCA type `File <https://docs.typo3.org/permalink/t3tca:columns-file>`_.
+
+When you are loping the object storage each element will be of type 
+:php:`\TYPO3\CMS\Extbase\Domain\Model\FileReference`. They can be used with the 
 :ref:`image <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-image>`
 argument:
 
@@ -103,6 +104,17 @@ argument:
     <f:for each="{mymodel.images}" as="image">
         <f:image image="{image}" class="something" height="250"/>
     </f:for>
+
+If the field may only contain one image maximal 
+(`maxitems=1  <https://docs.typo3.org/permalink/t3tca:confval-file-maxitems>`_)
+you can display this image directly by selecting
+the first array element:
+
+..  code-block:: html
+
+    <f:if condition="{mymodel.image.0}">
+        <f:image image="{mymodel.image.0}" class="something" height="250"/>
+    </f:if>
 
 ..  _typo3-fluid-image-uidreference:
 

--- a/Documentation/Global/Image.rst
+++ b/Documentation/Global/Image.rst
@@ -9,7 +9,8 @@ Image ViewHelper `<f:image>`
 
 ..  typo3:viewhelper:: image
     :source: ../Global.json
-    :display: tags,description,gitHubLink,arguments
+    :display: tags,description,gitHubLink
+    :noindex:
 
 ..  contents:: Table of contents
 

--- a/Documentation/Global/Image.rst
+++ b/Documentation/Global/Image.rst
@@ -71,7 +71,8 @@ See `Example: Render the images stored in field image <https://docs.typo3.org/pe
 in the TypoScript reference.
 
 You can then use the :ref:`image <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-image>`
-argument to pass the :php-short:`\TYPO3\CMS\Core\Resource\File or \TYPO3\CMS\Core\Resource\FileReference`
+argument to pass the :php-short:`\TYPO3\CMS\Core\Resource\File` or
+:php-short:`\TYPO3\CMS\Core\Resource\FileReference`
 provided by the TypoScript data processor to the ViewHelper.
 
 ..  code-block:: html

--- a/Documentation/Global/Image.rst
+++ b/Documentation/Global/Image.rst
@@ -29,8 +29,8 @@ argument and the `EXT:` syntax:
 
     <f:image src="EXT:my_site_package/Resources/Public/images/typo3_logo.png" alt="alt text" />
 
-The assets **must** be stored in folder :path:`Resources/Public/` or a sub
-folder of an extension.
+The assets **must** be stored in folder :path:`Resources/Public/` of an extension or a sub
+folder thereof.
 
 If you installed the extension via Composer **before** it had a folder of that
 exact name, reinstall it so that the symlinks in folder :path:`public/_assets`

--- a/Documentation/Global/Image.rst
+++ b/Documentation/Global/Image.rst
@@ -82,7 +82,7 @@ provided by the TypoScript data processor to the ViewHelper.
     </f:for>
 
 The :abbr:`FAL (file abstraction layer)` will take care of scaling the image and
-converting it to a web format if necessary (for example a pdf to a png).
+converting it to a web format if necessary (for example from a pdf to a png).
 
 The `<f:image>` ViewHelper generates a HTML `<img>` tag with the correct paths etc.
 

--- a/Documentation/Global/Image.rst
+++ b/Documentation/Global/Image.rst
@@ -74,7 +74,7 @@ You can then use the :ref:`image <t3viewhelper:viewhelper-argument-typo3-cms-flu
 argument to pass the :php-short:`\TYPO3\CMS\Core\Resource\File or \TYPO3\CMS\Core\Resource\FileReference`
 provided by the TypoScript data processor to the ViewHelper.
 
-..  code-block:: HTML
+..  code-block:: html
 
     <f:for each="{images}" as="image">
         <f:image image="{image}" class="something" height="250" alt="Description"/>
@@ -97,7 +97,7 @@ field may contain several images. They can then be displayed using the
 :ref:`image <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-image>`
 argument:
 
-..  code-block:: HTML
+..  code-block:: html
 
     <f:for each="{mymodel.images}" as="image">
         <f:image image="{image}" class="something" height="250"/>

--- a/Documentation/Global/Image.rst
+++ b/Documentation/Global/Image.rst
@@ -142,10 +142,10 @@ the typolink string starting with `t3://file` as
 
 ..  code-block:: html
 
-    <f:image image="{file.link}" height="250"/>
+    <f:image src="{file.link}" height="250"/>
 
     <!-- File with uid 928 -->
-    <f:image image="t3://file?uid=928" height="250"/>
+    <f:image src="t3://file?uid=928" height="250"/>
 
 ..  _typo3-fluid-image-example:
 

--- a/Documentation/Global/Image.rst
+++ b/Documentation/Global/Image.rst
@@ -11,71 +11,144 @@ Image ViewHelper `<f:image>`
     :source: ../Global.json
     :display: tags,description,gitHubLink,arguments
 
+..  contents:: Table of contents
+
+..  _typo3-fluid-image-src:
+
+Argument src - displaying images from the extension assets
+==========================================================
+
+Images used for design purposes and not content purposes are commonly shipped
+with an extension. These images cannot be edited by backend users. They can be
+displayed using the `<f:image>` ViewHelper using the
+:ref:`src <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-src>`
+argument and the `EXT:` syntax:
+
+..  code-block:: html
+
+    <f:image src="EXT:my_site_package/Resources/Public/images/typo3_logo.png" alt="alt text" />
+
+The assets **must** be stored in folder :path:`Resources/Public/` or a sub
+folder of an extension.
+
+If you installed the extension via Composer **before** it had a folder of that
+exact name, reinstall it so that the symlinks in folder :path:`public/_assets`
+are correctly created for you.
+
+..  note::
+
+    Avoid using image operations, such as the arguments
+    :ref:`width <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-width>` or
+    :ref:`crop <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-crop>`
+    with images included from an extensions' assets. Each
+    non-FAL image operation creates a "fake" FAL record, which may lead to problems.
+
+..  _typo3-fluid-image-image:
+
+Argument image - display images from the folder fileadmin / from FAL
+====================================================================
+
+Folders from within the folder :path:`fileadmin` are usually accessed using the
+`file abstraction layer (FAL) <https://docs.typo3.org/permalink/t3coreapi:fal-introduction>`_.
+
+For example, if you want to display an image that is attached to a content
+element, the content element typically stores a reference count of attached images in
+its field `media`. Intermediate tables are then used to attach the actual image
+to the content elements. This allows backend users to move or rename files,
+while the files connection is not lost in the content element.
+
+..  _typo3-fluid-image-fluidtemplate:
+
+FLUIDTEMPLATE and data processors and images
+--------------------------------------------
+
+In a TypoScript `FLUIDTEMPLATE <https://docs.typo3.org/permalink/t3tsref:cobj-template>`_
+you can use the `files data processor <https://docs.typo3.org/permalink/t3tsref:filesprocessor>`_
+to display an image with the `<f:image>` ViewHelper.
+
+See `Example: Render the images stored in field image <https://docs.typo3.org/permalink/t3tsref:filesprocessor-example-render-image>`_
+in the TypoScript reference.
+
+You can then use the :ref:`image <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-image>`
+argument to pass the :php-short:`\TYPO3\CMS\Core\Resource\File or \TYPO3\CMS\Core\Resource\FileReference`
+provided by the TypoScript data processor to the ViewHelper.
+
+..  code-block:: HTML
+
+    <f:for each="{images}" as="image">
+        <f:image image="{image}" class="something" height="250" alt="Description"/>
+    </f:for>
+
+The :abbr:`FAL (file abstraction layer)` will take care of scaling the image and
+converting it to a web format if necessary (for example a pdf to a png).
+
+The `<f:image>` ViewHelper generates a HTML `<img>` tag with the correct paths etc.
+
+..  _typo3-fluid-image-extbase:
+
+Images from Extbase models in Fluid
+-----------------------------------
+
+In Extbase models you can use fields of type
+:php:`\TYPO3\CMS\Extbase\Domain\Model\FileReference` if a field may contain
+maximal one image and :php:`\TYPO3\CMS\Extbase\Persistence\ObjectStorage` if a
+field may contain several images. They can then be displayed using the
+:ref:`image <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-image>`
+argument:
+
+..  code-block:: HTML
+
+    <f:for each="{mymodel.images}" as="image">
+        <f:image image="{image}" class="something" height="250"/>
+    </f:for>
+
+..  _typo3-fluid-image-uidreference:
+
+Using the UID of the database entry directly
+============================================
+
+Using :php-short:`\TYPO3\CMS\Extbase\Domain\Model\FileReference` objects is the
+preferred way of displaying an image in Fluid. However if only the UID of
+database entry is available you can also use the `<f:image>` ViewHelper with the
+UID.
+
+If the UID of the **sys_file** table is available you can pass this reference to
+the :ref:`src <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-src>`
+argument of the ViewHelper directly.
+
+If you have the UID of the **sys_file_reference** table you have to set
+:ref:`treatIdAsReference <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-treatidasreference>`
+to true additionally.
+
+..  code-block:: html
+
+    <f:image image="{file.uid}" height="250"/>
+    <f:image image="{reference.uid}" treatIdAsReference="1" class="something" height="250"/>
+
+    <!-- File with uid 42 -->
+    <f:image image="42" height="250"/>
+
+..  _typo3-fluid-image-typolink:
+
+Displaying an image from its typolink string
+============================================
+
+If the file was configured as typolink, for example from a TCA field of type
+`Link <https://docs.typo3.org/permalink/t3tca:columns-link>`_, you can use
+the typolink string starting with `t3://file` as
+:ref:`src <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-src>`:
+
+..  code-block:: html
+
+    <f:image image="{file.link}" height="250"/>
+
+    <!-- File with uid 928 -->
+    <f:image image="t3://file?uid=928" height="250"/>
+
 ..  _typo3-fluid-image-example:
 
-Examples
-========
-
-Default
--------
-
-::
-
-   <f:image src="EXT:myext/Resources/Public/typo3_logo.png" alt="alt text" />
-
-Output in frontend::
-
-   <img alt="alt text" src="typo3conf/ext/myext/Resources/Public/typo3_logo.png" width="396" height="375" />
-
-or in backend::
-
-   <img alt="alt text" src="../typo3conf/ext/viewhelpertest/Resources/Public/typo3_logo.png" width="396" height="375" />
-
-Image Object
-------------
-
-::
-
-   <f:image image="{imageObject}" />
-
-Output::
-
-   <img alt="alt set in image record" src="fileadmin/_processed_/323223424.png" width="396" height="375" />
-
-Inline notation
----------------
-
-::
-
-   {f:image(src: 'EXT:viewhelpertest/Resources/Public/typo3_logo.png', alt: 'alt text', minWidth: 30, maxWidth: 40)}
-
-Output::
-
-   <img alt="alt text" src="../typo3temp/assets/images/f13d79a526.png" width="40" height="38" />
-
-Depending on your TYPO3s encryption key.
-
-Other resource type (e.g. PDF)
-------------------------------
-
-::
-
-   <f:image src="fileadmin/user_upload/example.pdf" alt="foo" />
-
-If your graphics processing library is set up correctly then it will output a thumbnail of the first page of your PDF document:
-``<img src="fileadmin/_processed_/1/2/csm_example_aabbcc112233.gif" width="200" height="284" alt="foo">``
-
-Non-existent image
-------------------
-
-::
-
-   <f:image src="NonExistingImage.png" alt="foo" />
-
-``Could not get image resource for "NonExistingImage.png".``
-
-Base64 attribute
-----------------
+Embedding SVG files with the base64 attribute
+=============================================
 
 When the :typo3:viewhelper-argument:`base64 <typo3-cms-fluid-viewhelpers-imageviewhelper-base64>`
 argument is set to true, the resulting image tag contains the source of the image in a base64
@@ -88,7 +161,8 @@ encoded form.
              class="pr-2"
     />
 
-Will result in the according HTML tag providing the image encoded in base64.
+This will result in the corresponding HTML tag providing the image encoded in
+base64.
 
 .. code-block:: html
 
@@ -97,4 +171,17 @@ Will result in the according HTML tag providing the image encoded in base64.
          alt=""
     >
 
-This can be particularly useful inside `FluidEmail` or to prevent unneeded HTTP calls.
+This can be particularly useful inside
+`FluidEmail <https://docs.typo3.org/permalink/t3coreapi:mail-fluid-email>`_
+or to prevent unneeded HTTP calls.
+
+..  _typo3-fluid-image-arguments:
+
+Arguments of the `<f:image>` ViewHelper
+=======================================
+
+..  include:: /_Includes/_ArbitraryArguments.rst.txt
+
+..  typo3:viewhelper:: image
+    :source: ../Global.json
+    :display: arguments-only

--- a/Documentation/Global/Image.rst
+++ b/Documentation/Global/Image.rst
@@ -121,26 +121,25 @@ the first array element:
 Using the UID of the database entry directly
 ============================================
 
-Using :php-short:`\TYPO3\CMS\Extbase\Domain\Model\FileReference` objects is the
-preferred way of displaying an image in Fluid. However if only the UID of
-database entry is available you can also use the `<f:image>` ViewHelper with the
-UID.
-
-If the UID of the **sys_file** table is available you can pass this value to
-the :ref:`src <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-src>`
-argument of the ViewHelper directly.
-
-If you have the UID of the **sys_file_reference** table you have to set
+If you have the UID of the **sys_file_reference** table (prefered) you have to set
 :ref:`treatIdAsReference <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-treatidasreference>`
-to true additionally.
+to true additionally and pass the UID of the file reference to the 
+ref:`src <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-src>`
+argument.
+
+If only the UID of the **sys_file** table is available you can pass this value to
+the :ref:`src <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-src>`
+argument of the ViewHelper directly, `treatIdAsReference` can be left to the default (false).
+In this case no data from the file reference such as default cropping or overrides for alt text and 
+description are available.
 
 ..  code-block:: html
 
-    <f:image image="{file.uid}" height="250"/>
-    <f:image image="{reference.uid}" treatIdAsReference="1" class="something" height="250"/>
+    <f:image src="{reference.uid}" treatIdAsReference="1" height="250"/>
+    <f:image src="{file.uid}" height="250" alt="My image description"/>
 
     <!-- File with uid 42 -->
-    <f:image image="42" height="250"/>
+    <f:image src="42" treatIdAsReference="1" class="something" height="250"/>
 
 ..  _typo3-fluid-image-typolink:
 

--- a/Documentation/Global/Image.rst
+++ b/Documentation/Global/Image.rst
@@ -114,7 +114,7 @@ preferred way of displaying an image in Fluid. However if only the UID of
 database entry is available you can also use the `<f:image>` ViewHelper with the
 UID.
 
-If the UID of the **sys_file** table is available you can pass this reference to
+If the UID of the **sys_file** table is available you can pass this value to
 the :ref:`src <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-src>`
 argument of the ViewHelper directly.
 

--- a/Documentation/Global/Image.rst
+++ b/Documentation/Global/Image.rst
@@ -16,21 +16,21 @@ Image ViewHelper `<f:image>`
 
 ..  _typo3-fluid-image-src:
 
-Argument src - displaying images from the extension assets
-==========================================================
+Argument src - displaying images from extension assets
+======================================================
 
 Images used for design purposes and not content purposes are commonly shipped
-with an extension. These images cannot be edited by backend users. They can be
+in an extension. These images cannot be edited by backend users. They can be
 displayed using the `<f:image>` ViewHelper using the
 :ref:`src <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-src>`
-argument and the `EXT:` syntax:
+argument and `EXT:` syntax:
 
 ..  code-block:: html
 
     <f:image src="EXT:my_site_package/Resources/Public/images/typo3_logo.png" alt="alt text" />
 
-The assets **must** be stored in folder :path:`Resources/Public/` of an extension or a sub
-folder thereof.
+In the extension the assets **must** be stored under :path:`Resources/Public/` or
+a subfolder of this folder.
 
 If you installed the extension via Composer **before** it had a folder of that
 exact name, reinstall it so that the symlinks in folder :path:`public/_assets`
@@ -38,7 +38,7 @@ are correctly created for you.
 
 ..  note::
 
-    Avoid using image operations, such as the arguments
+    Avoid using image operations such as the arguments
     :ref:`width <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-width>` or
     :ref:`crop <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-crop>`
     with images included from an extensions' assets. Each
@@ -49,14 +49,14 @@ are correctly created for you.
 Argument image - display images from the folder fileadmin / from FAL
 ====================================================================
 
-Folders from within the folder :path:`fileadmin` are usually accessed using the
+Folders from inside the folder :path:`fileadmin` are usually accessed using the
 `file abstraction layer (FAL) <https://docs.typo3.org/permalink/t3coreapi:fal-introduction>`_.
 
 For example, if you want to display an image that is attached to a content
 element, the content element typically stores a reference count of attached images in
-its field `media`. Intermediate tables are then used to attach the actual image
+its `media` field. Intermediate tables are then used to attach the actual image
 to the content elements. This allows backend users to move or rename files,
-while the files connection is not lost in the content element.
+without the files connection being lost in the content element.
 
 ..  _typo3-fluid-image-fluidtemplate:
 
@@ -81,21 +81,21 @@ provided by the TypoScript data processor to the ViewHelper.
         <f:image image="{image}" class="something" height="250" alt="Description"/>
     </f:for>
 
-The :abbr:`FAL (file abstraction layer)` will take care of scaling the image and
-converting it to a web format if necessary (for example from a pdf to a png).
+The :abbr:`FAL (file abstraction layer)` will scale the image and
+convert it to a web format if necessary (for example from a pdf to a png).
 
-The `<f:image>` ViewHelper generates a HTML `<img>` tag with the correct paths etc.
+The `<f:image>` ViewHelper generates a HTML `<img>` tag with the correct paths, etc.
 
 ..  _typo3-fluid-image-extbase:
 
 Images from Extbase models in Fluid
 -----------------------------------
 
-In Extbase models you can use fields of type :php:`\TYPO3\CMS\Extbase\Persistence\ObjectStorage` with 
+In Extbase models you can use fields of type :php:`\TYPO3\CMS\Extbase\Persistence\ObjectStorage` with
 the TCA type `File <https://docs.typo3.org/permalink/t3tca:columns-file>`_.
 
-When you are loping the object storage each element will be of type 
-:php:`\TYPO3\CMS\Extbase\Domain\Model\FileReference`. They can be used with the 
+When you are looping through the object storage, each element will be of type
+:php:`\TYPO3\CMS\Extbase\Domain\Model\FileReference`. They can be used with the
 :ref:`image <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-image>`
 argument:
 
@@ -105,9 +105,9 @@ argument:
         <f:image image="{image}" class="something" height="250"/>
     </f:for>
 
-If the field may only contain one image maximal 
-(`maxitems=1  <https://docs.typo3.org/permalink/t3tca:confval-file-maxitems>`_)
-you can display this image directly by selecting
+If the field should only contain a maximum of one image
+(`maxitems=1  <https://docs.typo3.org/permalink/t3tca:confval-file-maxitems>`_),
+you can display the image simply by selecting
 the first array element:
 
 ..  code-block:: html
@@ -121,17 +121,17 @@ the first array element:
 Using the UID of the database entry directly
 ============================================
 
-If you have the UID of the **sys_file_reference** table (prefered) you have to set
+If you have the UID of the **sys_file_reference** table (preferred) you have to set
 :ref:`treatIdAsReference <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-treatidasreference>`
-to true additionally and pass the UID of the file reference to the 
-ref:`src <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-src>`
+to true and pass the UID of the file reference to the
+:ref:`src <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-src>`
 argument.
 
-If only the UID of the **sys_file** table is available you can pass this value to
+If only the UID of the **sys_file** table is available, you can pass this value to
 the :ref:`src <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-src>`
-argument of the ViewHelper directly, `treatIdAsReference` can be left to the default (false).
-In this case no data from the file reference such as default cropping or overrides for alt text and 
-description are available.
+argument of the ViewHelper and `treatIdAsReference` can be kept as the default value (false).
+In this case no data from the file reference, such as default cropping or overrides for alt text and
+description, will be available.
 
 ..  code-block:: html
 
@@ -143,12 +143,12 @@ description are available.
 
 ..  _typo3-fluid-image-typolink:
 
-Displaying an image from its typolink string
-============================================
+Displaying an image using its typolink string
+=============================================
 
-If the file was configured as typolink, for example from a TCA field of type
+If the file is configured as a typolink, for example from a TCA field of type
 `Link <https://docs.typo3.org/permalink/t3tca:columns-link>`_, you can use
-the typolink string starting with `t3://file` as
+the typolink string, starting with `t3://file`, as
 :ref:`src <t3viewhelper:viewhelper-argument-typo3-cms-fluid-viewhelpers-imageviewhelper-src>`:
 
 ..  code-block:: html
@@ -164,7 +164,7 @@ Embedding SVG files with the base64 attribute
 =============================================
 
 When the :typo3:viewhelper-argument:`base64 <typo3-cms-fluid-viewhelpers-imageviewhelper-base64>`
-argument is set to true, the resulting image tag contains the source of the image in a base64
+argument is set to true, the resulting image tag will contain the source of the image in a base64
 encoded form.
 
 ..  code-block:: html
@@ -174,7 +174,7 @@ encoded form.
              class="pr-2"
     />
 
-This will result in the corresponding HTML tag providing the image encoded in
+This will result in the HTML tag providing the image encoded in
 base64.
 
 .. code-block:: html
@@ -186,7 +186,7 @@ base64.
 
 This can be particularly useful inside
 `FluidEmail <https://docs.typo3.org/permalink/t3coreapi:mail-fluid-email>`_
-or to prevent unneeded HTTP calls.
+or to prevent unnecessary HTTP calls.
 
 ..  _typo3-fluid-image-arguments:
 


### PR DESCRIPTION
- Clarify usage of `src` and `image` arguments
- Add examples for FAL, Extbase, UID references, and typolink usage
- Include note on base64 embedding for SVGs
- Add cross-references to relevant TYPO3 documentation

Releases: main, 13.4