### PR TITLE
[TASK] Add "accept" attribute as example

### DIFF
--- a/Documentation/Global/Form/Upload.rst
+++ b/Documentation/Global/Form/Upload.rst
@@ -47,9 +47,14 @@ Example for allowed MIME types / file extensions (native HTML5 attribute)
     :caption: HTML output
 
    <input type="file" name="file" accept=".gif,.jpg,image/jpg,image/jpeg,image/gif" />
+
 ..  hint::
 
-    Please be aware that the `accept` attribute is a native HTML5 element. It has no specific Extbase or Fluid implementation, so validation of the incoming file is only performed in the client. It does not replace proper validation on the backend / server side, so proper `UploadedFile` or Extbase File-Upload-Handling validation needs to be implemented, too.
+    The `accept` attribute is a native HTML5 element. It has no specific Extbase or Fluid implementation, 
+    and validation of the incoming file is only performed on the client. It does not replace proper 
+    server-side validation, so :php-short:`\TYPO3\CMS\Core\Http\UploadedFile` or Extbase file-upload 
+    handling must still be implemented.
+
 ..  _typo3-fluid-form-upload-arguments:
 
 Arguments of f:form.upload


### PR DESCRIPTION
Since "accept" is not specifically listed (because it's HTML5 functionality, not ViewHelper), but very important for file uploads, an example for it is added.

Code formatting changes also applied.