### PR TITLE
[BUGFIX] Show active page in page tree for shared FormEngine links

### DIFF
--- a/Documentation/Backend/Link/EditRecord.rst
+++ b/Documentation/Backend/Link/EditRecord.rst
@@ -11,5 +11,10 @@
 Link.editRecord ViewHelper `<be:link.editRecord>`
 =================================================
 
+..  versionadded:: 14.0
+    Argument :ref:`module <t3viewhelper:viewhelper-argument-typo3-cms-backend-viewhelpers-link-editrecordviewhelper-module>`
+    has been added to explicitly define the backend module context used when
+    opening the FormEngine to edit or create a record.
+
 ..  typo3:viewhelper:: link.editRecord
     :source: ../../Backend.json

--- a/Documentation/Backend/Link/NewRecord.rst
+++ b/Documentation/Backend/Link/NewRecord.rst
@@ -11,5 +11,10 @@
 Link.newRecord ViewHelper `<be:link.newRecord>`
 ===============================================
 
+..  versionadded:: 14.0
+    Argument :ref:`module <t3viewhelper:viewhelper-argument-typo3-cms-backend-viewhelpers-link-newrecordviewhelper-module>`
+    has been added to explicitly define the backend module context used when
+    opening the FormEngine to edit or create a record.
+
 ..  typo3:viewhelper:: link.newRecord
     :source: ../../Backend.json

--- a/Documentation/Backend/Uri/EditRecord.rst
+++ b/Documentation/Backend/Uri/EditRecord.rst
@@ -11,5 +11,10 @@
 Uri.editRecord ViewHelper `<be:uri.editRecord>`
 ===============================================
 
+..  versionadded:: 14.0
+    Argument :ref:`module <t3viewhelper:viewhelper-argument-typo3-cms-backend-viewhelpers-uri-editrecordviewhelper-module>`
+    has been added to explicitly define the backend module context used when
+    opening the FormEngine to edit or create a record.
+
 ..  typo3:viewhelper:: uri.editRecord
     :source: ../../Backend.json

--- a/Documentation/Backend/Uri/NewRecord.rst
+++ b/Documentation/Backend/Uri/NewRecord.rst
@@ -11,5 +11,10 @@
 Uri.newRecord ViewHelper `<be:uri.newRecord>`
 =============================================
 
+..  versionadded:: 14.0
+    Argument :ref:`module <t3viewhelper:viewhelper-argument-typo3-cms-backend-viewhelpers-uri-newrecordviewhelper-module>`
+    has been added to explicitly define the backend module context used when
+    opening the FormEngine to edit or create a record.
+
 ..  typo3:viewhelper:: uri.newRecord
     :source: ../../Backend.json


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1364
Releases: main