### PR TITLE
[BUGFIX] Add missing closing quote (") in Text.rst

### DIFF
--- a/Documentation/Global/Render/Text.rst
+++ b/Documentation/Global/Render/Text.rst
@@ -63,7 +63,7 @@ example of type `Input <https://docs.typo3.org/permalink/t3tca:columns-input-ren
         ..  code-block:: html
             :caption: my_theme/Resources/Private/Templates/Content/MyContentElement.fluid.html
 
-            <f:render.text record="{record} field="my_title" />
+            <f:render.text record="{record}" field="my_title" />
             or
             {f:render.text(record: record, field: 'my_title')}
             or


### PR DESCRIPTION
There is a closing `"` missing in the first line of [Text.rst](https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/Global/Render/Text.html#fluid-tab-tabs-32) after the `record` attribute value:
```html
<f:render.text record="{record} field="my_title" />
```